### PR TITLE
Fix hang on mac and linux

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -38,8 +38,12 @@ static unsigned int __inline TRAILING_ZEROES( unsigned int x ) {
 #else
 #	include <sys/types.h>
 #	include <sys/mman.h>
-#	define TRAILING_ONES(x)		(~(x)?__builtin_ctz(~(x)):32)
-#	define TRAILING_ZEROES(x)	(x?__builtin_ctz(x):32)
+static inline unsigned int TRAILING_ONES( unsigned int x ) {
+	return (~x) ? __builtin_ctz(~x) : 32;
+}
+static inline unsigned int TRAILING_ZEROES( unsigned int x ) {
+	return x ? __builtin_ctz(x) : 32;
+}
 #endif
 #	define MZERO(ptr,size)		memset(ptr,0,size)	
 


### PR DESCRIPTION
The TRAILING_ZEROES macro did not ensure correct evaluation order (it behaved incorrectly when x was a ternary expression for example). To fix this I've replaced these macros with inline functions. Adding brackets around the first x in the TRAILING_ZEROES macro would have worked as well, but we're probably better off using an inline function in this case.

Resolves issue #9